### PR TITLE
Add keyCommandListeners as a property to the Editor

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -53,7 +53,6 @@ export default React.createClass({
 
   getInitialState() {
     const decorator = new CompositeDecorator(this.props.decorators);
-    this.keyCommandListeners = List(this.props.keyCommandListeners);
     return {
       decorator
     };
@@ -64,6 +63,10 @@ export default React.createClass({
       editorState: this.getDecoratedState(),
       onChange: this.props.onChange
     };
+  },
+
+  componentWillMount() {
+    this.keyCommandListeners = List(this.props.keyCommandListeners);
   },
 
   componentWillReceiveProps(nextProps) {

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -27,6 +27,8 @@ const propTypes = {
   onDownArrow: PropTypes.func
 };
 
+let keyCommandListeners = List();
+
 export default React.createClass({
   propTypes,
 
@@ -53,10 +55,10 @@ export default React.createClass({
 
   getInitialState() {
     const decorator = new CompositeDecorator(this.props.decorators);
+    keyCommandListeners = List(this.props.keyCommandListeners);
 
     return {
-      decorator,
-      keyCommandListeners: List(this.props.keyCommandListeners)
+      decorator
     };
   },
 
@@ -81,16 +83,12 @@ export default React.createClass({
   },
 
   addKeyCommandListener(listener) {
-    this.setState({
-      keyCommandListeners: this.state.keyCommandListeners.unshift(listener)
-    });
+    keyCommandListeners = keyCommandListeners.unshift(listener);
   },
 
   removeKeyCommandListener(listener) {
-    this.setState({
-      keyCommandListeners: this.state.keyCommandListeners.filterNot((l) => {
-        return l === listener;
-      })
+    keyCommandListeners = keyCommandListeners.filterNot((l) => {
+      return l === listener;
     });
   },
 
@@ -104,7 +102,6 @@ export default React.createClass({
   },
 
   handleKeyCommand(command, keyboardEvent = null) {
-    const {keyCommandListeners} = this.state;
     const decoratedState = this.getDecoratedState();
 
     const result = keyCommandListeners.reduce(({state, hasChanged}, listener) => {

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -27,8 +27,6 @@ const propTypes = {
   onDownArrow: PropTypes.func
 };
 
-let keyCommandListeners = List();
-
 export default React.createClass({
   propTypes,
 
@@ -55,8 +53,7 @@ export default React.createClass({
 
   getInitialState() {
     const decorator = new CompositeDecorator(this.props.decorators);
-    keyCommandListeners = List(this.props.keyCommandListeners);
-
+    this.keyCommandListeners = List(this.props.keyCommandListeners);
     return {
       decorator
     };
@@ -83,11 +80,11 @@ export default React.createClass({
   },
 
   addKeyCommandListener(listener) {
-    keyCommandListeners = keyCommandListeners.unshift(listener);
+    this.keyCommandListeners = this.keyCommandListeners.unshift(listener);
   },
 
   removeKeyCommandListener(listener) {
-    keyCommandListeners = keyCommandListeners.filterNot((l) => {
+    this.keyCommandListeners = this.keyCommandListeners.filterNot((l) => {
       return l === listener;
     });
   },
@@ -104,7 +101,7 @@ export default React.createClass({
   handleKeyCommand(command, keyboardEvent = null) {
     const decoratedState = this.getDecoratedState();
 
-    const result = keyCommandListeners.reduce(({state, hasChanged}, listener) => {
+    const result = this.keyCommandListeners.reduce(({state, hasChanged}, listener) => {
       if (hasChanged === true) {
         return {
           state,


### PR DESCRIPTION
### Changes

When `keyCommandListeners` lived in the component's state, some key command listeners were never being added to the list of key command listeners. This was due to race conditions caused by React's `setState()` function being asynchronous. Changing the `addKeyCommandListener` to a synchronous function will prevent these race conditions in the future.