### PR TITLE
non-mutating Object.assign calls

### DIFF
--- a/src/plugins/createPlugin.js
+++ b/src/plugins/createPlugin.js
@@ -160,8 +160,8 @@ const createPlugin = ({
           return oldOptions.textToEntity(text).concat(textToEntity(text));
         };
 
-        const newStyleToHTML = Object.assign(oldOptions.styleToHTML, styleToHTML);
-        const newBlockToHTML = Object.assign(oldOptions.blockToHTML, blockToHTML);
+        const newStyleToHTML = Object.assign({}, oldOptions.styleToHTML, styleToHTML);
+        const newBlockToHTML = Object.assign({}, oldOptions.blockToHTML, blockToHTML);
 
         const newEntityToHTML = (entity, originalText) => {
           const acc = oldOptions.entityToHTML(entity, originalText);


### PR DESCRIPTION
Fix an unintentional choice to make `Object.assign` calls mutating when accumulating `styleToHTML` and `blockToHTML` options to build an augmented conversion function. When building more than one conversion function with directly conflicting functionality this caused issues with functionality bleeding between converters.