### PR TITLE
Switch editorState context to be a getEditorState function

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -31,7 +31,7 @@ export default React.createClass({
   propTypes,
 
   childContextTypes: {
-    editorState: PropTypes.instanceOf(EditorState),
+    getEditorState: PropTypes.func,
     onChange: PropTypes.func
   },
 
@@ -60,7 +60,7 @@ export default React.createClass({
 
   getChildContext() {
     return {
-      editorState: this.getDecoratedState(),
+      getEditorState: this.getDecoratedState,
       onChange: this.props.onChange
     };
   },


### PR DESCRIPTION
Fixes issues where `editorState` passed down by context to decorators or other components within the `Editor` tree that don't update enough because [`shouldComponentUpdate` for the editor block component](https://github.com/facebook/draft-js/blob/master/src/component/contents/DraftEditorBlock.react.js#L60-L73) stops any update when changes happen to other blocks.

I think most situations where someone would want to make changes within a decorator would only make changes to data pertaining to that range of text, the associated entity, or the block, but issues arise with applications that autosave when only calling `Entity.mergeData` since it isn't part of the editor state.

I'm open to the idea of switching these to use the [Decorator `props` option](https://github.com/facebook/draft-js/blob/master/src/model/decorators/DraftDecorator.js#L38) instead of context but that seems out of the scope of this issue and I want to make sure that custom block components also get free access to editor state and a change callback.