### PR TITLE
Handle blockToHTML function

### DIFF
--- a/example/blockStyles.html
+++ b/example/blockStyles.html
@@ -21,7 +21,7 @@
     <script src="../node_modules/es6-shim/es6-shim.js"></script>
     <script src="../node_modules/babel-standalone/babel.min.js"></script>
     <script src="../node_modules/draft-js/dist/Draft.js"></script>
-    <script src="../build/draft-extend.js"></script>
+    <script src="../dist/draft-extend.js"></script>
     <script src="../node_modules/draft-convert/build/draft-convert.js"></script>
     <script src="./ToolbarButton.js"></script>
     <script type="text/babel">

--- a/example/inlineStyles.html
+++ b/example/inlineStyles.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>draft-extend</title>
     <link rel="stylesheet" href="../node_modules/draft-js/dist/Draft.css" />
-    <link rel="stylesheet" href="../build/draft-extend.css" />
+    <link rel="stylesheet" href="../dist/draft-extend.css" />
     <style>
       #target {
         font-family: sans-serif;
@@ -21,8 +21,8 @@
     <script src="../node_modules/es6-shim/es6-shim.js"></script>
     <script src="../node_modules/babel-standalone/babel.min.js"></script>
     <script src="../node_modules/draft-js/dist/Draft.js"></script>
-    <script src="../build/draft-extend.js"></script>
-    <script src="../node_modules/draft-convert/build/draft-convert.js"></script>
+    <script src="../dist/draft-extend.js"></script>
+    <script src="../node_modules/draft-convert/dist/draft-convert.js"></script>
     <script src="./ToolbarButton.js"></script>
     <script type="text/babel">
       const {

--- a/example/link.html
+++ b/example/link.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>draft-extend</title>
     <link rel="stylesheet" href="../node_modules/draft-js/dist/Draft.css" />
-    <link rel="stylesheet" href="../build/draft-extend.css" />
+    <link rel="stylesheet" href="../dist/draft-extend.css" />
     <style>
       #target {
         font-family: sans-serif;
@@ -21,8 +21,8 @@
     <script src="../node_modules/es6-shim/es6-shim.js"></script>
     <script src="../node_modules/babel-standalone/babel.min.js"></script>
     <script src="../node_modules/draft-js/dist/Draft.js"></script>
-    <script src="../build/draft-extend.js"></script>
-    <script src="../node_modules/draft-convert/build/draft-convert.js"></script>
+    <script src="../dist/draft-extend.js"></script>
+    <script src="../node_modules/draft-convert/dist/draft-convert.js"></script>
     <script src="./ToolbarButton.js"></script>
     <script type="text/babel">
       const {

--- a/example/mention.html
+++ b/example/mention.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>draft-extend</title>
     <link rel="stylesheet" href="../node_modules/draft-js/dist/Draft.css" />
-    <link rel="stylesheet" href="../build/draft-extend.css" />
+    <link rel="stylesheet" href="../dist/draft-extend.css" />
     <style>
       #target {
         font-family: sans-serif;
@@ -21,8 +21,8 @@
     <script src="../node_modules/es6-shim/es6-shim.js"></script>
     <script src="../node_modules/babel-standalone/babel.min.js"></script>
     <script src="../node_modules/draft-js/dist/Draft.js"></script>
-    <script src="../build/draft-extend.js"></script>
-    <script src="../node_modules/draft-convert/build/draft-convert.js"></script>
+    <script src="../dist/draft-extend.js"></script>
+    <script src="../node_modules/draft-convert/dist/draft-convert.js"></script>
     <script src="./ToolbarButton.js"></script>
     <script type="text/babel">
       const {

--- a/example/token.html
+++ b/example/token.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>draft-extend</title>
     <link rel="stylesheet" href="../node_modules/draft-js/dist/Draft.css" />
-    <link rel="stylesheet" href="../build/draft-extend.css" />
+    <link rel="stylesheet" href="../dist/draft-extend.css" />
     <style>
       #target {
         font-family: sans-serif;
@@ -21,8 +21,8 @@
     <script src="../node_modules/es6-shim/es6-shim.js"></script>
     <script src="../node_modules/babel-standalone/babel.min.js"></script>
     <script src="../node_modules/draft-js/dist/Draft.js"></script>
-    <script src="../build/draft-extend.js"></script>
-    <script src="../node_modules/draft-convert/build/draft-convert.js"></script>
+    <script src="../dist/draft-extend.js"></script>
+    <script src="../node_modules/draft-convert/dist/draft-convert.js"></script>
     <script src="./ToolbarButton.js"></script>
     <script type="text/babel">
       const {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "author": "Ben Briggs",
   "dependencies": {
-    "draft-js": "^0.6.0",
+    "draft-js": "^0.8.1",
     "immutable": "^3.8.1",
     "invariant": "^2.2.1",
     "react": "^15.0.2",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
     "draft-js"
   ],
   "author": "Ben Briggs",
+  "peerDependencies": {
+    "draft-js": ">=0.7.0",
+    "react": ">=15.0.2",
+    "react-dom": ">=15.0.2"
+  },
   "dependencies": {
-    "draft-js": "^0.8.1",
     "immutable": "^3.8.1",
-    "invariant": "^2.2.1",
-    "react": "^15.0.2",
-    "react-dom": "^15.0.2"
+    "invariant": "^2.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",
@@ -39,8 +41,11 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-standalone": "^6.7.7",
-    "draft-convert": "^1.1.0",
+    "draft-convert": "^1.2.0",
+    "draft-js": "^0.8.1",
     "es6-shim": "^0.35.0",
+    "react": "^15.0.2",
+    "react-dom": "^15.0.2",
     "webpack": "^1.13.0"
   }
 }

--- a/src/util/accumulateFunction.js
+++ b/src/util/accumulateFunction.js
@@ -1,0 +1,9 @@
+// utility function to accumulate the common plugin option function pattern of
+// handling args by returning a non-null result or delegate to other plugins
+export default (newFn, acc) => (...args) => {
+  const result = newFn(...args);
+  if (result === null || result === undefined) {
+    return acc(...args);
+  }
+  return result;
+};

--- a/src/util/blockTypeObjectFunction.js
+++ b/src/util/blockTypeObjectFunction.js
@@ -1,0 +1,9 @@
+export default function blockTypeObjectFunction(typeObject) {
+  if (typeof typeObject === 'function') {
+    return typeObject;
+  }
+
+  return (block) => {
+    return typeObject[block.type];
+  };
+}


### PR DESCRIPTION
https://github.com/HubSpot/draft-convert/pull/10 will allow `blockToHTML` to be a function so that block metadata can be inspected. Added the ability when accumulating conversion options in plugins for `blockToHTML` to be either a style object (the old behavior) or a new function that accumulates the same way as others.

I took the opportunity to unify how functions are accumulated across `createPlugin`'s implementation.