### PR TITLE
Add getReadOnly method to context of Editor component

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -24,7 +24,8 @@ const propTypes = {
   onEscape: PropTypes.func,
   onTab: PropTypes.func,
   onUpArrow: PropTypes.func,
-  onDownArrow: PropTypes.func
+  onDownArrow: PropTypes.func,
+  readOnly: PropTypes.bool
 };
 
 export default React.createClass({
@@ -32,6 +33,7 @@ export default React.createClass({
 
   childContextTypes: {
     getEditorState: PropTypes.func,
+    getReadOnly: PropTypes.func,
     onChange: PropTypes.func
   },
 
@@ -47,7 +49,8 @@ export default React.createClass({
       blockRendererFn: () => {},
       blockStyleFn: () => {},
       keyBindingFn: () => {},
-      keyCommandListeners: []
+      keyCommandListeners: [],
+      readOnly: false
     };
   },
 
@@ -61,6 +64,7 @@ export default React.createClass({
   getChildContext() {
     return {
       getEditorState: this.getDecoratedState,
+      getReadOnly: this.getReadOnly,
       onChange: this.props.onChange
     };
   },
@@ -178,6 +182,10 @@ export default React.createClass({
       acc[prop] = this.props[prop];
       return acc;
     }, {});
+  },
+
+  getReadOnly() {
+    return this.props.readOnly;
   },
 
   getDecoratedState() {


### PR DESCRIPTION
Adds `getReadOnly` method to `Editor` component child context. Useful for checking the read-only status of the editor in a decorator component, such as a link that should `preventDefault` when being edited but should be triggered when in read-only mode.

Like with `getEditorState` the value is wrapped in a function to avoid any `shouldComponentUpdate`s in blocks preventing updates.