### PR TITLE
Middleware conversion configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ***
 
 ## Overview
-Draft Extend is a platform to build a full-featured Draft.js editor using modular plugins that can integrate with [draft-convert](#) to serialize with HTML. The higher-order function API makes it extremely easy to use any number of plugins for rendering and conversion.
+Draft Extend is a platform to build a full-featured Draft.js editor using modular plugins that can integrate with [draft-convert](http://github.com/HubSpot/draft-convert) to serialize with HTML. The higher-order function API makes it extremely easy to use any number of plugins for rendering and conversion.
 
 #### Usage:
 ```javascript

--- a/building-plugins.md
+++ b/building-plugins.md
@@ -135,25 +135,25 @@ const AlignmentPlugin = createPlugin({
 
 **Options**
 - `styleToHTML: (next: function) => (style: string) => (ReactElement | MarkupObject)` - Function that takes inline style types and returns an empty `ReactElement` (most likely created via JS) or HTML markup for output. A `MarkupObject` is an object of shape `{start, end}`, for example:
-    ```javascript
-    const styleToHTML = (style) => {
-        if (style === 'BOLD') {
-            return {
-                start: '<strong>',
-                end: '</strong>'
-            };
-        }
-    };
-    ```
-- `blockToHTML: (next: function) => (block: RawBlock) => (ReactElement | {element: ReactElement, nest?: ReactElement} | BlockMarkupObject)` - Function accepting a raw block object and returning `ReactElement`s or HTML markup for output. If using `ReactElement`s as return values for nestable blocks (`ordered-list-item` and `unordered-list-item`), a `ReactElement` for both the wrapping element and the block being nested may be included in an object of shape `{element, nest}`. A `BlockMarkupObject` is identical to `MarkupObject` with the exception of nestable blocks. These block types include properties for handling nesting. The default values for `ordered-list-item` are:
-    ```javascript
-    {
-        start: '<li>',
-        end: '</li>',
-        nestStart: '<ol>',
-        nestEnd: '</ol>'
+```javascript
+const styleToHTML = (style) => {
+    if (style === 'BOLD') {
+        return {
+            start: '<strong>',
+            end: '</strong>'
+        };
     }
-    ```
+};
+```
+- `blockToHTML: (next: function) => (block: RawBlock) => (ReactElement | {element: ReactElement, nest?: ReactElement} | BlockMarkupObject)` - Function accepting a raw block object and returning `ReactElement`s or HTML markup for output. If using `ReactElement`s as return values for nestable blocks (`ordered-list-item` and `unordered-list-item`), a `ReactElement` for both the wrapping element and the block being nested may be included in an object of shape `{element, nest}`. A `BlockMarkupObject` is identical to `MarkupObject` with the exception of nestable blocks. These block types include properties for handling nesting. The default values for `ordered-list-item` are:
+```javascript
+{
+    start: '<li>',
+    end: '</li>',
+    nestStart: '<ol>',
+    nestEnd: '</ol>'
+}
+```
 - `entityToHTML: (next: function) => (entity: RawEntity, originalText: string): (ReactElement | MarkupObject | string)` - Function to transform instances into HTML output. A `RawEntity` is an object of shape `{type: string, mutability: string, data: object}`. If the returned `ReactElement` contains no children it will be wrapped around `originalText`. A `MarkupObject` will also be wrapped around `orignalText`.
 - `htmlToStyle: (next: function) => (nodeName: string, node: Node) => OrderedSet` - Function that is passed an HTML Node. It should return a list of styles to be applied to all children of the node. The function will be invoked on all HTML nodes in the input.
 - `htmlToBlock: (next: function) => (nodeName: string, node: Node) => RawBlock | string` - Function that inspects an HTML `Node` and can return data to assign to the block in the shape `{type, data}`. If no data is necessary a block type may be returned as a string. If no custom type should be used it may return `null` or `undefined`.
@@ -186,15 +186,15 @@ A collection of useful functions for building plugins.
 - `camelCaseToHyphen: function(camelCase: string): string` - Converts a camelCased word to a hyphenated-string. Used in `styleObjectToString`.
 - `styleObjectToString: function(styles: object): string` -  Converts a style object (i.e. object passed into the `style` prop of a React component) to a CSS string for use in a `style` HTML attribute. Useful for converting inline style types to HTML while keeping a single source of truth for the style for both `styleMap` and `styleToHTML`.
 - `entityStrategy: function(entityType: string): function(contentBlock, callback)` - factory function to generate decorator strategies to decorate all instances of a given entity type. For example:
-    ```
-        const MyPlugin = createPlugin({
-            ...
-            decorators: {
-                strategy: entityStrategy('myEntity'),
-                component: MyEntityComponent
-            }
-        });
-    ```
+```javascript
+    const MyPlugin = createPlugin({
+        ...
+        decorators: {
+            strategy: entityStrategy('myEntity'),
+            component: MyEntityComponent
+        }
+    });
+```
 - `getEntitySelection: function(editorState: EditorState, entityKey: string): SelectionState` - Returns the selection of an Entity instance in `editorState` with key `entityKey`.
 - `getSelectedInlineStyles: function(editorState): Set` - Returns a `Set` of all inline style types matched by any character in the current selection. Ths acts differently from `EditorState.getCurrentInlineStyle()` when the selection is not collapsed since `getSelectedInlineStyles` will include styles from every character in the selection instead of the single character at the focus index of the selection.
 - `getActiveEntity(editorState: EditorState): ?string` - Returns the key for the Entity that the current selection start is within, if it exists. Returns `undefined` if the selection start is not within an entity range.

--- a/example/blockStyles.html
+++ b/example/blockStyles.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>draft-extend</title>
     <link rel="stylesheet" href="../node_modules/draft-js/dist/Draft.css" />
-    <link rel="stylesheet" href="../build/draft-extend.css" />
+    <link rel="stylesheet" href="../dist/draft-extend.css" />
     <style>
       #target {
         font-family: sans-serif;
@@ -17,12 +17,13 @@
     <div id="target"></div>
     <script src="../node_modules/react/dist/react.min.js"></script>
     <script src="../node_modules/react-dom/dist/react-dom.min.js"></script>
+    <script src="../node_modules/react-dom/dist/react-dom-server.min.js"></script>
     <script src="../node_modules/immutable/dist/immutable.min.js"></script>
     <script src="../node_modules/es6-shim/es6-shim.js"></script>
     <script src="../node_modules/babel-standalone/babel.min.js"></script>
     <script src="../node_modules/draft-js/dist/Draft.js"></script>
     <script src="../dist/draft-extend.js"></script>
-    <script src="../node_modules/draft-convert/build/draft-convert.js"></script>
+    <script src="../node_modules/draft-convert/dist/draft-convert.js"></script>
     <script src="./ToolbarButton.js"></script>
     <script type="text/babel">
       const {

--- a/example/inlineStyles.html
+++ b/example/inlineStyles.html
@@ -17,6 +17,7 @@
     <div id="target"></div>
     <script src="../node_modules/react/dist/react.min.js"></script>
     <script src="../node_modules/react-dom/dist/react-dom.min.js"></script>
+    <script src="../node_modules/react-dom/dist/react-dom-server.min.js"></script>
     <script src="../node_modules/immutable/dist/immutable.min.js"></script>
     <script src="../node_modules/es6-shim/es6-shim.js"></script>
     <script src="../node_modules/babel-standalone/babel.min.js"></script>
@@ -48,6 +49,15 @@
         {label: 'Strikethrough', style: 'STRIKETHROUGH'}
       ];
 
+      const styleToHTML = (style) => {
+        if (style === 'STRIKETHROUGH') {
+          return <s />;
+        }
+        if (style === 'CODE') {
+          return <div style={{fontFamily: 'monospace'}} />;
+        }
+      };
+
       const createInlineStyle = ({label, style}) => {
         return ({editorState, onChange}) => {
           const toggleStyle = () => {
@@ -74,7 +84,8 @@
       };
 
       const InlinePlugin = createPlugin({
-        buttons: INLINE_STYLES.map(createInlineStyle)
+        buttons: INLINE_STYLES.map(createInlineStyle),
+        styleToHTML
       });
 
       const WithPlugin = InlinePlugin(Editor);

--- a/example/link.html
+++ b/example/link.html
@@ -17,6 +17,7 @@
     <div id="target"></div>
     <script src="../node_modules/react/dist/react.min.js"></script>
     <script src="../node_modules/react-dom/dist/react-dom.min.js"></script>
+    <script src="../node_modules/react-dom/dist/react-dom-server.min.js"></script>
     <script src="../node_modules/immutable/dist/immutable.min.js"></script>
     <script src="../node_modules/es6-shim/es6-shim.js"></script>
     <script src="../node_modules/babel-standalone/babel.min.js"></script>

--- a/example/mention.html
+++ b/example/mention.html
@@ -17,6 +17,7 @@
     <div id="target"></div>
     <script src="../node_modules/react/dist/react.min.js"></script>
     <script src="../node_modules/react-dom/dist/react-dom.min.js"></script>
+    <script src="../node_modules/react-dom/dist/react-dom-server.min.js"></script>
     <script src="../node_modules/immutable/dist/immutable.min.js"></script>
     <script src="../node_modules/es6-shim/es6-shim.js"></script>
     <script src="../node_modules/babel-standalone/babel.min.js"></script>
@@ -219,6 +220,7 @@
                 style={{
                   margin: '0',
                   padding: '0',
+                  fontFamily: 'sans-serif'
                 }}
               >
                 <li
@@ -262,7 +264,8 @@
             <ul
               style={{
                 margin: '0',
-                padding: '0'
+                padding: '0',
+                fontFamily: 'sans-serif'
               }}
             >
               {this.renderResults()}

--- a/example/token.html
+++ b/example/token.html
@@ -17,6 +17,7 @@
     <div id="target"></div>
     <script src="../node_modules/react/dist/react.min.js"></script>
     <script src="../node_modules/react-dom/dist/react-dom.min.js"></script>
+    <script src="../node_modules/react-dom/dist/react-dom-server.min.js"></script>
     <script src="../node_modules/immutable/dist/immutable.min.js"></script>
     <script src="../node_modules/es6-shim/es6-shim.js"></script>
     <script src="../node_modules/babel-standalone/babel.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-standalone": "^6.7.7",
-    "draft-convert": "^1.2.0",
+    "draft-convert": "^1.3.1",
     "draft-js": "^0.8.1",
     "es6-shim": "^0.35.0",
     "react": "^15.0.2",

--- a/src/plugins/createPlugin.js
+++ b/src/plugins/createPlugin.js
@@ -10,6 +10,7 @@ const emptyArray = [];
 const emptyObject = {};
 
 const defaultMiddlewareFunction = (next) => (...args) => next(...args);
+defaultMiddlewareFunction.__isMiddleware = true;
 
 const memoizedCompose = memoize(compose);
 const memoizedAccumulateFunction = memoize(accumulateFunction);

--- a/src/util/blockTypeObjectFunction.js
+++ b/src/util/blockTypeObjectFunction.js
@@ -1,9 +1,0 @@
-export default function blockTypeObjectFunction(typeObject) {
-  if (typeof typeObject === 'function') {
-    return typeObject;
-  }
-
-  return (block) => {
-    return typeObject[block.type];
-  };
-}

--- a/src/util/middlewareAdapter.js
+++ b/src/util/middlewareAdapter.js
@@ -1,4 +1,3 @@
-import {isValidElement} from 'react';
 import {OrderedSet} from 'immutable';
 
 // function to handle previous techniques to convert to HTML, including
@@ -53,7 +52,8 @@ const middlewareAdapter = (middleware) => {
         returnValue = nonMiddlewareResult.concat(next(...args));
       } else if (OrderedSet.isOrderedSet(nonMiddlewareResult)) {
         // returned an OrderedSet from htmlToStyle, pass to next as third argument
-        returnValue = nonMiddlewareResult.union(next(...args));
+        const previousStyles = args[args.length - 1];
+        returnValue = previousStyles.union(nonMiddlewareResult).union(next(...args));
       } else if (typeof nonMiddlewareResult === 'function') {
         // most middleware HOFs will return another function when invoked, so we
         // can assume that it is one here

--- a/src/util/middlewareAdapter.js
+++ b/src/util/middlewareAdapter.js
@@ -1,0 +1,67 @@
+import {isValidElement} from 'react';
+
+// function to handle previous techniques to convert to HTML, including
+// plain objects with `{start, end}` values and non-HOF functions that return
+// either a String or ReactElement
+
+const middlewareAdapter = (middleware) => (next) => (...args) => {
+  if (typeof middleware === 'object') {
+    // handle old blockToHTML objects
+    const block = args[0];
+
+    let objectResult;
+
+    if (typeof block === 'string') {
+      // handle case of inline style value
+      const style = block;
+      if (process.env.NODE_ENV === 'development') {
+        console.warn('styleToHTML: Use of plain objects to define HTML output is being deprecated. Please switch to using functions that return a {start, end} object or ReactElement.');
+      }
+
+      objectResult = middleware[style];
+    } else {
+      if (process.env.NODE_ENV === 'development') {
+        console.warn('blockToHTML: Use of plain objects to define HTML output is being deprecated. Please switch to using functions that return a {start, end} object or ReactElement.');
+      }
+
+      objectResult = middleware[block.type];
+    }
+
+    // check for inline style value instead of a raw block
+    if (objectResult !== null && objectResult !== undefined) {
+      return objectResult;
+    }
+    return next(...args);
+  }
+
+  let returnValue;
+  try {
+    // try immediately giving the function the content data in case it's a simple
+    // function that doesn't expect a `next` function
+    const nonMiddlewareResult = middleware(...args);
+    if (nonMiddlewareResult === null || nonMiddlewareResult === undefined) {
+      // the behavior for non-middleware functions is to delegate by returning
+      // `null` or `undefined`, so do delegation for them
+      returnValue = next(...args);
+    } else if (typeof nonMiddlewareResult === 'string' || isValidElement(nonMiddlewareResult)) {
+      // the function was a simple non-middleware function and
+      // returned a reasonable value, so return its result
+      returnValue = nonMiddlewareResult;
+    } else if (typeof nonMiddlewareResult === 'function') {
+      // most middleware HOFs will return another function when invoked, so we
+      // can assume that it is one here
+      returnValue = middleware(next)(...args);
+    }
+  } catch (e) {
+    // it's possible that trying to use a middleware function like a simple non-
+    // middleware function will throw, so try it as a middleware HOF
+    returnValue = middleware(next)(...args);
+  } finally {
+    if (returnValue === undefined || returnValue === null) {
+      return next(...args);
+    }
+    return returnValue;
+  }
+};
+
+export default middlewareAdapter;

--- a/src/util/middlewareAdapter.js
+++ b/src/util/middlewareAdapter.js
@@ -47,6 +47,10 @@ const middlewareAdapter = (middleware) => {
         // the behavior for non-middleware functions is to delegate by returning
         // `null` or `undefined`, so do delegation for them
         returnValue = next(...args);
+      }
+      else if (args.length === 2 && typeof args[1] === 'string' && args[1] === nonMiddlewareResult) {
+        // entityToHTML option returned `originalText`, i.e. no change was made
+        returnValue = next(...args);
       } else if (Array.isArray(nonMiddlewareResult)) {
         // returned an array from a textToEntity function, concat with next
         returnValue = nonMiddlewareResult.concat(next(...args));

--- a/src/util/middlewareAdapter.js
+++ b/src/util/middlewareAdapter.js
@@ -1,67 +1,76 @@
 import {isValidElement} from 'react';
+import {OrderedSet} from 'immutable';
 
 // function to handle previous techniques to convert to HTML, including
 // plain objects with `{start, end}` values and non-HOF functions that return
 // either a String or ReactElement
 
-const middlewareAdapter = (middleware) => (next) => (...args) => {
-  if (typeof middleware === 'object') {
-    // handle old blockToHTML objects
-    const block = args[0];
-
-    let objectResult;
-
-    if (typeof block === 'string') {
-      // handle case of inline style value
-      const style = block;
-      if (process.env.NODE_ENV === 'development') {
-        console.warn('styleToHTML: Use of plain objects to define HTML output is being deprecated. Please switch to using functions that return a {start, end} object or ReactElement.');
-      }
-
-      objectResult = middleware[style];
-    } else {
-      if (process.env.NODE_ENV === 'development') {
-        console.warn('blockToHTML: Use of plain objects to define HTML output is being deprecated. Please switch to using functions that return a {start, end} object or ReactElement.');
-      }
-
-      objectResult = middleware[block.type];
-    }
-
-    // check for inline style value instead of a raw block
-    if (objectResult !== null && objectResult !== undefined) {
-      return objectResult;
-    }
-    return next(...args);
+const middlewareAdapter = (middleware) => {
+  if (middleware && middleware.__isMiddleware) {
+    return middleware;
   }
+  return (next) => (...args) => {
+    if (typeof middleware === 'object') {
+      // handle old blockToHTML objects
+      const block = args[0];
 
-  let returnValue;
-  try {
-    // try immediately giving the function the content data in case it's a simple
-    // function that doesn't expect a `next` function
-    const nonMiddlewareResult = middleware(...args);
-    if (nonMiddlewareResult === null || nonMiddlewareResult === undefined) {
-      // the behavior for non-middleware functions is to delegate by returning
-      // `null` or `undefined`, so do delegation for them
-      returnValue = next(...args);
-    } else if (typeof nonMiddlewareResult === 'string' || isValidElement(nonMiddlewareResult)) {
-      // the function was a simple non-middleware function and
-      // returned a reasonable value, so return its result
-      returnValue = nonMiddlewareResult;
-    } else if (typeof nonMiddlewareResult === 'function') {
-      // most middleware HOFs will return another function when invoked, so we
-      // can assume that it is one here
-      returnValue = middleware(next)(...args);
-    }
-  } catch (e) {
-    // it's possible that trying to use a middleware function like a simple non-
-    // middleware function will throw, so try it as a middleware HOF
-    returnValue = middleware(next)(...args);
-  } finally {
-    if (returnValue === undefined || returnValue === null) {
+      let objectResult;
+
+      if (typeof block === 'string') {
+        // handle case of inline style value
+        const style = block;
+        if (process.env.NODE_ENV === 'development') {
+          console.warn('styleToHTML: Use of plain objects to define HTML output is being deprecated. Please switch to using functions that return a {start, end} object or ReactElement.');
+        }
+
+        objectResult = middleware[style];
+      } else {
+        if (process.env.NODE_ENV === 'development') {
+          console.warn('blockToHTML: Use of plain objects to define HTML output is being deprecated. Please switch to using functions that return a {start, end} object or ReactElement.');
+        }
+
+        objectResult = middleware[block.type];
+      }
+
+      // check for inline style value instead of a raw block
+      if (objectResult !== null && objectResult !== undefined) {
+        return objectResult;
+      }
       return next(...args);
     }
-    return returnValue;
-  }
+
+    let returnValue;
+    try {
+      // try immediately giving the function the content data in case it's a simple
+      // function that doesn't expect a `next` function
+      const nonMiddlewareResult = middleware(...args);
+      if (nonMiddlewareResult === null || nonMiddlewareResult === undefined) {
+        // the behavior for non-middleware functions is to delegate by returning
+        // `null` or `undefined`, so do delegation for them
+        returnValue = next(...args);
+      } else if (Array.isArray(nonMiddlewareResult)) {
+        // returned an array from a textToEntity function, concat with next
+        returnValue = nonMiddlewareResult.concat(next(...args));
+      } else if (OrderedSet.isOrderedSet(nonMiddlewareResult)) {
+        // returned an OrderedSet from htmlToStyle, pass to next as third argument
+        returnValue = nonMiddlewareResult.union(next(...args));
+      } else if (typeof nonMiddlewareResult === 'function') {
+        // most middleware HOFs will return another function when invoked, so we
+        // can assume that it is one here
+        returnValue = middleware(next)(...args);
+      } else {
+        // the function was a simple non-middleware function and
+        // returned a reasonable value, so return its result
+        returnValue = nonMiddlewareResult;
+      }
+    } catch (e) {
+      // it's possible that trying to use a middleware function like a simple non-
+      // middleware function will throw, so try it as a middleware HOF
+      returnValue = middleware(next)(...args);
+    } finally {
+      return returnValue;
+    }
+  };
 };
 
 export default middlewareAdapter;


### PR DESCRIPTION
### shift to preferring middleware functions for conversion options, and preferring `ReactElement`s as return values for `toHTML` options.

All conversion options to HTML can now be functions that eventually return an empty `ReactElement`, with some other situations where you may want something simpler. I'll go through the possible signatures of each one in order of preference:
#### `blockToHTML`
- `(next: function) => (block: RawBlock) => (ReactElement | {start: string, end: string})` - Higher-order middleware function that allows for accumulation or transformation on the `ReactElement` generated by other plugins.
-  `(block: RawBlock) => (ReactElement | {start: string, end: string} | void)` - Simpler conversion function that may return a `ReactElement` to be accumulated on, but has no access to `next` to transform any other results. A `{start, end}` object probably isn't a good thing to accumulate on.   Returning `null` or `undefined` will cause the adapter to return `next(block)` so that the middleware chain isn't broken above it.
- `{[blockType: string]: ReactElement | {start: string, end: string}}` - Old plain object structure to be deprecated in favor of functions.
#### `entityToHTML`
- `(next: function) => (entity: RawEntity, originalText: string) => (ReactElement | {start: string, end: string} string)` - Higher-order middleware function to accumulate upon previous results. The `ReactElement` may be with or without children: if it is empty `originalText` will be inserted as the only child. When returning a `{start, end}` object the tags will be wrapped around `originalText`.
- `(entity: RawEntity, originalText: string) => (ReactElement | {start: string, end: string} | string)` - Simpler conversion for when accumulation isn't necessary.
#### `styleToHTML`
- `(next: function) => (style: string) => (ReactElement | {start: string, end: string})` - Higher-order middleware function to transform previous results.
- `(style: string) => (ReactElement | {start: string, end: string} | void)` - Simpler conversion function without middleware
- `{[styleName: string]: {start: string, end: string}}` - Old object structure to be deprecated in favor of functions
#### `htmlToBlock`
- `(next: function) => (nodeName: string, node: Node, lastList: string, inBlock: string) => ?RawBlock` - Higher-order middleware function to transform previous results.
- `(nodeName: string, node: Node, lastList: string, inBlock: string) => ?RawBlock` - Simpler block detection when transformation isn't necessary.
#### `htmlToEntity`
- `(next: function) => (nodeName: string, node: Node) => ?DraftEntityKey` - Higher-order middleware function to transform previous results.
- `(nodeName: string, node: Node) => ?DraftEntityKey` - Simpler entity detection when transformation isn't necessary.
#### `htmlToEntity`
- `(next: function) => (nodeName: string, node: Node) => ?DraftEntityKey` - Higher-order middleware function to transform previous results.
- `(nodeName: string, node: Node) => ?DraftEntityKey` - Simpler entity detection when transformation isn't necessary.
#### `htmlToStyle`
- `(next: function) => (nodeName: string, node: Node) => OrderedSet<DraftInlineStyle>` - Higher-order middleware function to transform previous results.
- `(nodeName: string, node: Node) => OrderedSet<DraftInlineStyle>` - Simpler entity detection when transformation isn't necessary.
#### `textToEntity`
- `(next: function) => (text: string) => Array<TextEntityObject>` - Higher-order middleware function to transform previous results.
- `(text: string) => Array<TextEntityObject>` - Simpler entity detection when transformation isn't necessary.

TODO: 
- [x] rewrite docs to properly prioritize how to build config options
