### PR TITLE
Create function to pass reference to the actual editor through plugin chain

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -173,6 +173,10 @@ export default React.createClass({
     this.refs.editor.blur();
   },
 
+  getEditor() {
+    return this;
+  },
+
   getOtherProps() {
     const propKeys = Object.keys(this.props);
     const propTypeKeys = Object.keys(propTypes);

--- a/src/plugins/createPlugin.js
+++ b/src/plugins/createPlugin.js
@@ -87,6 +87,12 @@ const createPlugin = ({
         }
       },
 
+      getEditor() {
+        if (this.refs.child.getEditor) {
+          return this.refs.child.getEditor();
+        }
+      },
+
       render() {
         const newStyleMap = memoizedAssign(this.props.styleMap, styleMap);
         const newDecorators = memoizedConcat(this.props.decorators, decorators);


### PR DESCRIPTION
- allow easy access to prepared props, state, renderers, &c.
  - initial goal was to get access to button renderer but thought making it generic made more sense