### PR TITLE
Use renderSubtreeIntoContainer to render overlay

### DIFF
--- a/src/components/OverlayWrapper.js
+++ b/src/components/OverlayWrapper.js
@@ -23,7 +23,7 @@ export default React.createClass({
 
   renderOverlay() {
     const child = React.Children.only(this.props.children);
-    ReactDOM.render(child, this.state.node);
+    ReactDOM.unstable_renderSubtreeIntoContainer(this, child, this.state.node);
   },
 
   render() {


### PR DESCRIPTION
Use renderSubtreeIntoContainer instead of render to give children access to the context

Docs [here](https://github.com/facebook/react/blob/cb6da8e922c426dfae11a5da159ff9e8e176ce59/src/renderers/dom/stack/client/ReactMount.js#L409)