### PR TITLE
switch out order of rendering, refactor css

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -213,15 +213,14 @@ export default React.createClass({
 
     return this.props.buttons.map((Button, index) => {
       return (
-        <li key={`button-${index}`}>
-          <Button
-            {...this.getOtherProps()}
-            editorState={decoratedState}
-            onChange={this.props.onChange}
-            addKeyCommandListener={this.addKeyCommandListener}
-            removeKeyCommandListener={this.removeKeyCommandListener}
-          />
-        </li>
+        <Button
+          {...this.getOtherProps()}
+          addKeyCommandListener={this.addKeyCommandListener}
+          editorState={decoratedState}
+          key={`button${index}`}
+          onChange={this.props.onChange}
+          removeKeyCommandListener={this.removeKeyCommandListener}
+        />
       );
     });
   },
@@ -260,9 +259,6 @@ export default React.createClass({
 
     return (
       <div className={className}>
-        <ul className="draft-extend-controls">
-          {this.renderPluginButtons()}
-        </ul>
         <div className="draft-extend-editor">
           <Editor
             {...otherProps}
@@ -281,6 +277,9 @@ export default React.createClass({
             onUpArrow={this.onUpArrow}
             onDownArrow={this.onDownArrow}
           />
+          <div className="draft-extend-controls">
+            {this.renderPluginButtons()}
+          </div>
           <div className="draft-extend-overlays">
             {this.renderOverlays()}
           </div>

--- a/src/style/draft-extend.css
+++ b/src/style/draft-extend.css
@@ -1,23 +1,24 @@
-.draft-extend {
-  position: relative;
-  min-height: 40px;
-}
-
 .draft-extend-editor {
-  border-bottom: solid transparent 40px;
   padding: 4px;
 }
 
-.draft-extend-controls {
-  position: absolute;
-  bottom: 5px;
-  left: 5px;
-  margin: 0;
-  padding: 0;
+.DraftEditor-root {
+  padding-bottom: 1rem;
 }
 
-.draft-extend-controls > li {
+.draft-extend-controls {
+  padding: 0;
+  margin: 0;
+}
+
+.draft-extend-controls > * {
   display: inline-block;
   list-style-type: none;
-  margin: 0 1px;
+  margin: 0;
+  margin-right: 4px;
+}
+
+.draft-extend-controls > *:last-child {
+  display: inline-block;
+  margin-right: 0;
 }


### PR DESCRIPTION
@benbriggs 

# Pros
- DOM rendering matches visual representation which also fixed `tabIndex` order
- Removed `absolute` positioning, content now manages its own space
- Removed the `li` from the button so that we can have granular control over the child elements (with something like `flexbox`)
- Reduced css selectors that people will have to ⚔  with down the road.

# Con
Will break current implementations (probably)…but not that badly. Just if people were depending on the `li` or not including our CSS (because they wanted buttons at the top).  But this will allow for granular control from each supplied button so in the long run, I think it's a win.


# Consideration
- I considered adding a prop that removes buttons below from `tabIndex` but ultimately decided against it for two reasons:
  1. Would have to clone each element, adding the prop (if the child element takes it)
  2. I'm not sure the option would be used with regard for all people using this.
- Adding a prop for buttons at the top or the bottom. Happy to put it in if there's demand but I don't think there should be. If someone wants buttons at the top they can use the following css (doesn't change tab order): 
```css
.draft-extend {
  display: -webkit-box;
  display: -webkit-flex;
  display: -ms-flexbox;
  display: flex;
  -webkit-box-orient: vertical;
  -webkit-box-direction: normal;
  -webkit-flex-direction: column;
      -ms-flex-direction: column;
          flex-direction: column;
}

.DraftEditor-root {
  -webkit-box-ordinal-group: 3;
  -webkit-order: 2;
      -ms-flex-order: 2;
          order: 2;
}

.draft-extend-controls {
  -webkit-box-ordinal-group: 2;
  -webkit-order: 1;
      -ms-flex-order: 1;
          order: 1;
}

```