### PR TITLE
Separate key command controller and add Toolbar component

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,48 @@ const EditorWithPlugins = plugins(Editor);
 const toHTML = plugins(convertToHTML);
 const fromHTML = plugins(convertFromHTML);
 ```
+
+***
+
+## KeyCommandController
+**Higher-order component to consolidate key command listeners across the component tree**
+
+An increasingly common pattern for rich text editors is a toolbar detached from the main `Editor` component. This toolbar will be outside of the `Editor` component subtree, but will often need to respond to key commands that would otherwise be encapsulated by the `Editor`. `KeyCommandController` is a higher-order component that allows the subscription to key commands to move up the React tree so that components outside that subtree may listen and emit changes to editor state. `KeyCommandController`. It may be used with any component, but a good example is the `Toolbar` component:
+
+```javascript
+import {Editor, Toolbar, KeyCommandController, compose} from 'draft-extend';
+
+const plugins = compose(
+  FirstPlugin,
+  SecondPlugin
+);
+
+const WrappedEditor = plugins(Editor);
+const WrappedToolbar = plugins(Toolbar);
+
+const Parent = ({editorState, onChange, handleKeyCommand, addKeyCommandListener, removeKeyCommandListener}) => {
+  return (
+    <div>
+      <WrappedEditor
+        editorState={editorState}
+        onChange={onChange}
+        handleKeyCommand={handleKeyCommand}
+        addKeyCommandListener={addKeyCommandListener}
+        removeKeyCommandListener={removeKeyCommandListener}
+      />
+      <Toolbar
+        editorState={editorState}
+        onChange={onChange}
+        addKeyCommandListener={addKeyCommandListener}
+        removeKeyCommandListener={removeKeyCommandListener}
+      />
+    </div>
+  );
+};
+
+export default KeyCommandController(Parent);
+```
+
+`KeyCommandController` provides the final `handleKeyCommand` to use in the `Editor` component as well as subscribe/unsubscribe functions. As long as these props are passed from some common parent wrapped with `KeyCommandController` that also receives `editorState` and `onChange` props, other components may subscribe and emit chagnes to the editor state.
+
+Additionally, `KeyCommandController`s are composable and will defer to the highest parent instance. That is, if a `KeyCommandController` receives `handleKeyCommand`, `addKeyCommandListener`, and `removeKeyCommandListener` props (presumably from another controller) it will delegate to that controller's record of subscribed functions, keeping all listeners in one place.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ const Parent = ({editorState, onChange, handleKeyCommand, addKeyCommandListener,
         addKeyCommandListener={addKeyCommandListener}
         removeKeyCommandListener={removeKeyCommandListener}
       />
-      <Toolbar
+      <WrappedToolbar
         editorState={editorState}
         onChange={onChange}
         addKeyCommandListener={addKeyCommandListener}

--- a/example/blockStyles.html
+++ b/example/blockStyles.html
@@ -33,6 +33,8 @@
 
       const {
         Editor,
+        Toolbar,
+        KeyCommandController,
         createPlugin
       } = window.DraftExtend;
 
@@ -88,6 +90,7 @@
       });
 
       const WithPlugin = BlockPlugin(Editor);
+      const WithPluginToolbar = BlockPlugin(Toolbar);
       const toHTML = BlockPlugin(convertToHTML);
       const fromHTML = BlockPlugin(convertFromHTML);
 
@@ -107,16 +110,26 @@
 
         render() {
           return (
-            <WithPlugin
-              editorState={this.state.editorState}
-              onChange={this.onChange}
-            />
+            <div>
+              <WithPlugin
+                {...this.props}
+                editorState={this.state.editorState}
+                onChange={this.onChange}
+              />
+              <WithPluginToolbar
+                {...this.props}
+                editorState={this.state.editorState}
+                onChange={this.onChange}
+              />
+            </div>
           );
         }
       });
 
+      const WrappedComponent = KeyCommandController(BlockStylesExample);
+
       ReactDOM.render(
-        <BlockStylesExample />,
+        <WrappedComponent />,
         document.getElementById('target')
       );
     </script>

--- a/example/inlineStyles.html
+++ b/example/inlineStyles.html
@@ -111,6 +111,7 @@
             <WithPlugin
               editorState={this.state.editorState}
               onChange={this.onChange}
+              keyCommandListeners={[Draft.RichUtils.handleKeyCommand]}
             />
           );
         }

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -27,7 +27,8 @@ const propTypes = {
   onTab: PropTypes.func,
   onUpArrow: PropTypes.func,
   onDownArrow: PropTypes.func,
-  readOnly: PropTypes.bool
+  readOnly: PropTypes.bool,
+  showButtons: PropTypes.bool
 };
 
 const EditorWrapper = React.createClass({
@@ -54,7 +55,8 @@ const EditorWrapper = React.createClass({
       blockRendererFn: () => {},
       blockStyleFn: () => {},
       keyBindingFn: () => {},
-      readOnly: false
+      readOnly: false,
+      showButtons: true
     };
   },
 
@@ -166,8 +168,13 @@ const EditorWrapper = React.createClass({
     const {
       onChange,
       addKeyCommandListener,
-      removeKeyCommandListener
+      removeKeyCommandListener,
+      showButtons
     } = this.props;
+
+    if (showButtons === false) {
+      return null;
+    }
 
     const decoratedState = this.getDecoratedState();
 
@@ -176,6 +183,7 @@ const EditorWrapper = React.createClass({
         <Button
           {...this.getOtherProps()}
           key={`button-${index}`}
+          attachedToEditor={true}
           editorState={decoratedState}
           onChange={onChange}
           addKeyCommandListener={addKeyCommandListener}

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -6,6 +6,7 @@ import {
   CompositeDecorator,
   getDefaultKeyBinding
 } from 'draft-js';
+import KeyCommandController from './KeyCommandController';
 import OverlayWrapper from './OverlayWrapper';
 
 const propTypes = {
@@ -19,7 +20,9 @@ const propTypes = {
   blockRendererFn: PropTypes.func,
   blockStyleFn: PropTypes.func,
   keyBindingFn: PropTypes.func,
-  keyCommandListeners: PropTypes.arrayOf(PropTypes.func),
+  addKeyCommandListener: PropTypes.func.isRequired,
+  removeKeyCommandListener: PropTypes.func.isRequired,
+  keyCommandListener: PropTypes.func.isRequired,
   handleReturn: PropTypes.func,
   onEscape: PropTypes.func,
   onTab: PropTypes.func,
@@ -28,7 +31,7 @@ const propTypes = {
   readOnly: PropTypes.bool
 };
 
-export default React.createClass({
+const EditorWrapper = React.createClass({
   propTypes,
 
   childContextTypes: {
@@ -52,7 +55,6 @@ export default React.createClass({
       blockRendererFn: () => {},
       blockStyleFn: () => {},
       keyBindingFn: () => {},
-      keyCommandListeners: [],
       readOnly: false
     };
   },
@@ -93,16 +95,6 @@ export default React.createClass({
     this.setState({decorator: new CompositeDecorator(nextProps.decorators)});
   },
 
-  addKeyCommandListener(listener) {
-    this.keyCommandListeners = this.keyCommandListeners.unshift(listener);
-  },
-
-  removeKeyCommandListener(listener) {
-    this.keyCommandListeners = this.keyCommandListeners.filterNot((l) => {
-      return l === listener;
-    });
-  },
-
   keyBindingFn(e) {
     const pluginsCommand = this.props.keyBindingFn(e);
     if (pluginsCommand) {
@@ -112,61 +104,24 @@ export default React.createClass({
     return getDefaultKeyBinding(e);
   },
 
-  handleKeyCommand(command, keyboardEvent = null) {
-    const decoratedState = this.getDecoratedState();
-
-    const result = this.keyCommandListeners.reduce(({state, hasChanged}, listener) => {
-      if (hasChanged === true) {
-        return {
-          state,
-          hasChanged
-        };
-      }
-
-      const listenerResult = listener(state, command, keyboardEvent);
-      const isEditorState = listenerResult instanceof EditorState;
-
-      if (listenerResult === true || (isEditorState && listenerResult !== state)) {
-        if (isEditorState) {
-          this.props.onChange(listenerResult);
-          return {
-            state: listenerResult,
-            hasChanged: true
-          };
-        }
-        return {
-          state,
-          hasChanged: true
-        };
-      }
-
-      return {
-        state,
-        hasChanged
-      };
-    }, {state: decoratedState, hasChanged: false});
-
-    return result.hasChanged;
-  },
-
   handleReturn(e) {
-    return (this.props.handleReturn && this.props.handleReturn(e)) || this.handleKeyCommand('return', e);
+    return (this.props.handleReturn && this.props.handleReturn(e)) || this.props.handleKeyCommand('return', e);
   },
 
   onEscape(e) {
-    return (this.props.onEscape && this.props.onEscape(e)) || this.handleKeyCommand('escape', e);
+    return (this.props.onEscape && this.props.onEscape(e)) || this.props.handleKeyCommand('escape', e);
   },
 
   onTab(e) {
-    return (this.props.onTab && this.props.onTab(e)) || this.handleKeyCommand('tab', e);
+    return (this.props.onTab && this.props.onTab(e)) || this.props.handleKeyCommand('tab', e);
   },
 
   onUpArrow(e) {
-    return (this.props.onUpArrow && this.props.onUpArrow(e)) || this.handleKeyCommand('up-arrow', e);
+    return (this.props.onUpArrow && this.props.onUpArrow(e)) || this.props.handleKeyCommand('up-arrow', e);
   },
 
   onDownArrow(e) {
-    return (this.props.onDownArrow && this.props.onDownArrow(e)) || this.handleKeyCommand('down-arrow', e);
+    return (this.props.onDownArrow && this.props.onDownArrow(e)) || this.props.handleKeyCommand('down-arrow', e);
   },
 
   focus() {
@@ -213,23 +168,35 @@ export default React.createClass({
   },
 
   renderPluginButtons() {
+    const {
+      onChange,
+      addKeyCommandListener,
+      removeKeyCommandListener
+    } = this.props;
+
     const decoratedState = this.getDecoratedState();
 
     return this.props.buttons.map((Button, index) => {
       return (
         <Button
           {...this.getOtherProps()}
-          addKeyCommandListener={this.addKeyCommandListener}
           editorState={decoratedState}
-          key={`button${index}`}
-          onChange={this.props.onChange}
-          removeKeyCommandListener={this.removeKeyCommandListener}
+          onChange={onChange}
+          addKeyCommandListener={addKeyCommandListener}
+          removeKeyCommandListener={removeKeyCommandListener}
+          addKeyCommandListener={this.addKeyCommandListener}
         />
       );
     });
   },
 
   renderOverlays() {
+    const {
+      onChange,
+      addKeyCommandListener,
+      removeKeyCommandListener
+    } = this.props;
+
     const decoratedState = this.getDecoratedState();
 
     return this.props.overlays.map((Overlay, index) => {
@@ -238,9 +205,9 @@ export default React.createClass({
           <Overlay
             {...this.getOtherProps()}
             editorState={decoratedState}
-            onChange={this.props.onChange}
-            addKeyCommandListener={this.addKeyCommandListener}
-            removeKeyCommandListener={this.removeKeyCommandListener}
+            onChange={onChange}
+            addKeyCommandListener={addKeyCommandListener}
+            removeKeyCommandListener={removeKeyCommandListener}
           />
         </OverlayWrapper>
       );
@@ -253,6 +220,7 @@ export default React.createClass({
       blockRendererFn,
       blockStyleFn,
       onChange,
+      handleKeyCommand,
       ...otherProps
     } = this.props;
 
@@ -273,8 +241,8 @@ export default React.createClass({
             blockStyleFn={blockStyleFn}
             blockRendererFn={blockRendererFn}
             customStyleMap={styleMap}
+            handleKeyCommand={handleKeyCommand}
             keyBindingFn={this.keyBindingFn}
-            handleKeyCommand={this.handleKeyCommand}
             handleReturn={this.handleReturn}
             onEscape={this.onEscape}
             onTab={this.onTab}
@@ -292,3 +260,5 @@ export default React.createClass({
     );
   }
 });
+
+export default KeyCommandController(EditorWrapper);

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -175,6 +175,7 @@ const EditorWrapper = React.createClass({
       return (
         <Button
           {...this.getOtherProps()}
+          key={`button-${index}`}
           editorState={decoratedState}
           onChange={onChange}
           addKeyCommandListener={addKeyCommandListener}

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -184,7 +184,6 @@ const EditorWrapper = React.createClass({
           onChange={onChange}
           addKeyCommandListener={addKeyCommandListener}
           removeKeyCommandListener={removeKeyCommandListener}
-          addKeyCommandListener={this.addKeyCommandListener}
         />
       );
     });

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -22,7 +22,6 @@ const propTypes = {
   keyBindingFn: PropTypes.func,
   addKeyCommandListener: PropTypes.func.isRequired,
   removeKeyCommandListener: PropTypes.func.isRequired,
-  keyCommandListener: PropTypes.func.isRequired,
   handleReturn: PropTypes.func,
   onEscape: PropTypes.func,
   onTab: PropTypes.func,
@@ -76,10 +75,6 @@ const EditorWrapper = React.createClass({
       focus: this.focus,
       blur: this.blur
     };
-  },
-
-  componentWillMount() {
-    this.keyCommandListeners = List(this.props.keyCommandListeners);
   },
 
   componentWillReceiveProps(nextProps) {

--- a/src/components/KeyCommandController.js
+++ b/src/components/KeyCommandController.js
@@ -1,0 +1,113 @@
+'use es6';
+
+import {List} from 'immutable';
+import React, {PropTypes} from 'react';
+import {EditorState} from 'draft-js';
+
+export default (Component) => React.createClass({
+  propTypes: {
+    editorState: PropTypes.object,
+    onChange: PropTypes.func,
+    keyCommandListeners: PropTypes.arrayOf(PropTypes.func),
+    addKeyCommandListener: PropTypes.func,
+    removeKeyCommandListener: PropTypes.func,
+    handleKeyCommand: PropTypes.func
+  },
+
+  componentWillMount() {
+    this.keyCommandListeners = List(this.props.keyCommandListeners);
+  },
+
+  addKeyCommandListener(listener) {
+    const {addKeyCommandListener} = this.props;
+
+    if (addKeyCommandListener) {
+      addKeyCommandListener(listener);
+      return;
+    }
+
+    this.keyCommandListeners = this.keyCommandListeners.unshift(listener);
+  },
+
+  removeKeyCommandListener(listener) {
+    const {removeKeyCommandListener} = this.props;
+
+    if (removeKeyCommandListener) {
+      removeKeyCommandListener(listener);
+      return;
+    }
+
+    this.keyCommandListeners = this.keyCommandListeners.filterNot((l) => l === listener);
+  },
+
+  handleKeyCommand(command, keyboardEvent = null) {
+    const {editorState, onChange, handleKeyCommand} = this.props;
+
+    if (handleKeyCommand) {
+      return handleKeyCommand(command, keyboardEvent);
+    }
+
+    const result = this.keyCommandListeners.reduce(({state, hasChanged}, listener) => {
+      if (hasChanged === true) {
+        return {
+          state,
+          hasChanged
+        };
+      }
+
+      const listenerResult = listener(state, command, keyboardEvent);
+      const isEditorState = listenerResult instanceof EditorState;
+
+      if (listenerResult === true || (isEditorState && listenerResult !== state)) {
+        if (isEditorState) {
+          onChange(listenerResult);
+          return {
+            state: listenerResult,
+            hasChanged: true
+          };
+        }
+        return {
+          state,
+          hasChanged: true
+        };
+      }
+
+      return {
+        state,
+        hasChanged
+      };
+    }, {state: editorState, hasChanged: false});
+
+    return result.hasChanged;
+  },
+
+  focus() {
+    this.refs.editor.focus();
+  },
+
+  blur() {
+    this.refs.editor.blur();
+  },
+
+  render() {
+    const {
+      editorState,
+      onChange,
+      keyCommandListeners, // eslint-disable-line no-unused-vars
+      ...others
+    } = this.props;
+
+
+    return (
+      <Component
+        {...others}
+        ref="editor"
+        editorState={editorState}
+        onChange={onChange}
+        addKeyCommandListener={this.addKeyCommandListener}
+        removeKeyCommandListener={this.removeKeyCommandListener}
+        handleKeyCommand={this.handleKeyCommand}
+      />
+    );
+  }
+});

--- a/src/components/KeyCommandController.js
+++ b/src/components/KeyCommandController.js
@@ -26,7 +26,8 @@ const KeyCommandController = (Component) => React.createClass({
   },
 
   componentWillMount() {
-    this.keyCommandListeners = List(this.props.keyCommandListeners);
+    this.keyCommandOverrides = List(this.props.keyCommandListeners);
+    this.keyCommandListeners = List();
   },
 
   componentDidMount() {
@@ -85,7 +86,7 @@ const KeyCommandController = (Component) => React.createClass({
       return handleKeyCommand(command, keyboardEvent);
     }
 
-    const result = this.keyCommandListeners.reduce(({state, hasChanged}, listener) => {
+    const result = this.keyCommandOverrides.concat(this.keyCommandListeners).reduce(({state, hasChanged}, listener) => {
       if (hasChanged === true) {
         return {
           state,

--- a/src/components/KeyCommandController.js
+++ b/src/components/KeyCommandController.js
@@ -1,5 +1,3 @@
-'use es6';
-
 import {List} from 'immutable';
 import React, {PropTypes} from 'react';
 import {EditorState} from 'draft-js';

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -1,5 +1,3 @@
-'use es6';
-
 import React, {PropTypes} from 'react';
 import KeyCommandController from './KeyCommandController';
 

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -1,0 +1,48 @@
+'use es6';
+
+import React, {PropTypes} from 'react';
+import KeyCommandController from './KeyCommandController';
+
+const Toolbar = React.createClass({
+  propTypes: {
+    editorState: PropTypes.object,
+    onChange: PropTypes.func,
+    buttons: PropTypes.array,
+    addKeyCommandListener: PropTypes.func.isRequired,
+    removeKeyCommandListener: PropTypes.func.isRequired
+  },
+
+  renderButtons() {
+    const {
+      editorState,
+      onChange,
+      buttons,
+      addKeyCommandListener,
+      removeKeyCommandListener,
+      ...otherProps
+    } = this.props;
+
+    return buttons.map((Button, index) => {
+      return (
+        <Button
+          {...otherProps}
+          key={`button-${index}`}
+          editorState={editorState}
+          onChange={onChange}
+          addKeyCommandListener={addKeyCommandListener}
+          removeKeyCommandListener={removeKeyCommandListener}
+        />
+      );
+    });
+  },
+
+  render() {
+    return (
+      <ul className="draft-extend-controls">
+        {this.renderButtons()}
+      </ul>
+    );
+  }
+});
+
+export default KeyCommandController(Toolbar);

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -12,6 +12,22 @@ const Toolbar = React.createClass({
     removeKeyCommandListener: PropTypes.func.isRequired
   },
 
+  childContextTypes: {
+    getEditorState: PropTypes.func,
+    onChange: PropTypes.func
+  },
+
+  getChildContext() {
+    return {
+      getEditorState: this.getEditorState,
+      onChange: this.props.onChange
+    };
+  },
+
+  getEditorState() {
+    return this.props.editorState;
+  },
+
   renderButtons() {
     const {
       editorState,

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,14 @@
 import Editor from './components/Editor';
+import Toolbar from './components/Toolbar';
+import KeyCommandController from './components/KeyCommandController';
 import createPlugin from './plugins/createPlugin';
 import pluginUtils from './plugins/utils';
 import compose from './util/compose';
 
 export {
   Editor,
+  Toolbar,
+  KeyCommandController,
   createPlugin,
   pluginUtils,
   compose


### PR DESCRIPTION
### Separate out key command listener logic from `Editor` and turn it into a reusable higher-order component

Also adds a basic `Toolbar` component useful for building Medium-like editor toolbars detached from the `Editor` component. Together with `KeyCommandListener` it can be used to have full control over any key commands coming from the editor. Some notable omissions from things available within the Toolbar context are `focus`, `blur`, `getReadOnly`, and `setReadOnly`. Maybe in the future they could also be moved out of `Editor` but I don't think that makes as much sense as `KeyCommandController`