### PR TITLE
keyCommandListeners should have a priority over keyCommandOverrides

### DIFF
--- a/src/components/KeyCommandController.js
+++ b/src/components/KeyCommandController.js
@@ -86,7 +86,7 @@ const KeyCommandController = (Component) => React.createClass({
       return handleKeyCommand(command, keyboardEvent);
     }
 
-    const result = this.keyCommandOverrides.concat(this.keyCommandListeners).reduce(({state, hasChanged}, listener) => {
+    const result = this.keyCommandListeners.concat(this.keyCommandOverrides).reduce(({state, hasChanged}, listener) => {
       if (hasChanged === true) {
         return {
           state,


### PR DESCRIPTION
Dynamically added `keyCommandOverrides` should be a higher priority than `keyCommandListeners`.

@benbriggs 