### PR TITLE
add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "draft-js"
   ],
   "author": "Ben Briggs",
+  "license": "Apache License 2.0",
   "peerDependencies": {
     "draft-js": ">=0.7.0",
     "react": ">=15.0.2",


### PR DESCRIPTION
this will quell the console warning:

`npm WARN draft-extend@1.5.1 No license field.`