### PR TITLE
Allow react 16 as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "immutable": "^3.8.1",
-    "invariant": "^2.2.1"
+    "invariant": "^2.2.1",
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-dom": ">=15.0.2"
   },
   "dependencies": {
+    "create-react-class": "^15.6.2",
     "immutable": "^3.8.1",
     "invariant": "^2.2.1",
     "prop-types": "^15.6.0"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "author": "Ben Briggs",
   "peerDependencies": {
     "draft-js": ">=0.7.0",
-    "react": ">=15.0.2",
-    "react-dom": ">=15.0.2"
+    "react": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "create-react-class": "^15.6.2",

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,5 +1,6 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import {List} from 'immutable';
 import {
   Editor,
@@ -32,7 +33,7 @@ const propTypes = {
   showButtons: PropTypes.bool
 };
 
-const EditorWrapper = React.createClass({
+const EditorWrapper = createReactClass({
   propTypes,
 
   childContextTypes: {

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {List} from 'immutable';
 import {
   Editor,

--- a/src/components/KeyCommandController.js
+++ b/src/components/KeyCommandController.js
@@ -1,6 +1,7 @@
 import invariant from 'invariant';
 import {List} from 'immutable';
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {EditorState} from 'draft-js';
 
 const providedProps = {

--- a/src/components/KeyCommandController.js
+++ b/src/components/KeyCommandController.js
@@ -1,7 +1,8 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import invariant from 'invariant';
 import {List} from 'immutable';
-import PropTypes from 'prop-types';
-import React from 'react';
 import {EditorState} from 'draft-js';
 
 const providedProps = {
@@ -10,7 +11,7 @@ const providedProps = {
   handleKeyCommand: PropTypes.func
 };
 
-const KeyCommandController = (Component) => React.createClass({
+const KeyCommandController = (Component) => createReactClass({
   displayName: `KeyCommandController(${Component.displayName})`,
 
   propTypes: {

--- a/src/components/OverlayWrapper.js
+++ b/src/components/OverlayWrapper.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import createReactClass from 'create-react-class';
 
-export default React.createClass({
+export default createReactClass({
   getInitialState() {
     const node = document.createElement('div');
     document.body.appendChild(node);

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import KeyCommandController from './KeyCommandController';
 
 const Toolbar = React.createClass({

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -1,8 +1,9 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import KeyCommandController from './KeyCommandController';
 
-const Toolbar = React.createClass({
+const Toolbar = createReactClass({
   propTypes: {
     editorState: PropTypes.object,
     onChange: PropTypes.func,

--- a/src/plugins/createPlugin.js
+++ b/src/plugins/createPlugin.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {OrderedSet} from 'immutable';
 import memoize from '../util/memoize';
 import compose from '../util/compose';

--- a/src/plugins/createPlugin.js
+++ b/src/plugins/createPlugin.js
@@ -1,5 +1,6 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import {OrderedSet} from 'immutable';
 import memoize from '../util/memoize';
 import compose from '../util/compose';
@@ -49,7 +50,7 @@ const createPlugin = ({
 
   if (ToWrap.prototype && ToWrap.prototype.isReactComponent) {
     // wrapping an Editor component
-    return React.createClass({
+    return createReactClass({
       displayName,
 
       propTypes: {


### PR DESCRIPTION
Add `prop-types` & `create-react-class` packages to make the minimum amount of changes to be compatible with React 16.