### PR TITLE
Switch to babel env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   presets: [
-    'es2015',
+    'env',
     'react'
   ],
   plugins: [

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-core": "^6.7.7",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
-    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.5.0",
     "babel-standalone": "^6.7.7",
     "draft-convert": "^1.3.1",


### PR DESCRIPTION
`babel-preset-es2015` has been deprecated in favor of babel-reset-env: https://babeljs.io/env/