### PR TITLE
add baseDecorator prop defaulting to CompositeDecorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Other props are used by plugins composed around `Editor`. See [Building Plugins]
 - `buttons`: `Array<Component>` Array of React components to add to the controls of the editor.
 - `overlays`: `Array<Component>` Array of React components to add as overlays to the editor.
 - `decorators`: `Array<DraftDecorator>` Array of Draft.js decorator objects used to render the EditorState. They are added to the EditorState as a CompositeDecorator within the component and are of shape `{strategy, component}`.
+- `baseDecorator`: `DraftDecoratorType` Replacement decorator object to override the built-in `CompositeDecorator`'s behavior. See the "Beyond CompositeDecorator" section on [this page of the Draft.js docs](https://draftjs.org/docs/advanced-topics-decorators.html#content) for more information.
 - `styleMap`: `Object` Object map from Draft.js inline style type to style object. Used for the Draft.js Editor's `customStyleMap` prop.
 
 All other props are passed down to the [Draft.js `Editor` component](https://facebook.github.io/draft-js/docs/api-reference-editor.html) and to any buttons and overlays added by plugins.

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -16,6 +16,7 @@ const propTypes = {
   editorState: PropTypes.object,
   onChange: PropTypes.func,
   decorators: PropTypes.array,
+  baseDecorator: PropTypes.func,
   styleMap: PropTypes.object,
   buttons: PropTypes.array,
   overlays: PropTypes.array,
@@ -51,6 +52,7 @@ const EditorWrapper = createReactClass({
       editorState: EditorState.createEmpty(),
       onChange: () => {},
       decorators: [],
+      baseDecorator: CompositeDecorator,
       styleMap: {},
       buttons: [],
       overlays: [],
@@ -63,7 +65,9 @@ const EditorWrapper = createReactClass({
   },
 
   getInitialState() {
-    const decorator = new CompositeDecorator(this.props.decorators);
+    const { baseDecorator } = this.props;
+
+    const decorator = new baseDecorator(this.props.decorators);
     return {
       decorator,
       readOnly: false
@@ -91,7 +95,7 @@ const EditorWrapper = createReactClass({
       }
     }
 
-    this.setState({decorator: new CompositeDecorator(nextProps.decorators)});
+    this.setState({decorator: new nextProps.baseDecorator(nextProps.decorators)});
   },
 
   keyBindingFn(e) {


### PR DESCRIPTION
allows a custom replacement for `CompositeDecorator` to be passed (see 'Beyond CompositeDecorator' section of [this page](https://draftjs.org/docs/advanced-topics-decorators.html#content) for more context on usecases)