### PR TITLE
fix handleKeyCommand parameters

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -108,23 +108,28 @@ const EditorWrapper = createReactClass({
   },
 
   handleReturn(e) {
-    return (this.props.handleReturn && this.props.handleReturn(e)) || this.props.handleKeyCommand('return', e);
+    return (this.props.handleReturn && this.props.handleReturn(e)) ||
+      this.props.handleKeyCommand('return', this.props.editorState, e);
   },
 
   onEscape(e) {
-    return (this.props.onEscape && this.props.onEscape(e)) || this.props.handleKeyCommand('escape', e);
+    return (this.props.onEscape && this.props.onEscape(e)) ||
+      this.props.handleKeyCommand('escape', this.props.editorState, e);
   },
 
   onTab(e) {
-    return (this.props.onTab && this.props.onTab(e)) || this.props.handleKeyCommand('tab', e);
+    return (this.props.onTab && this.props.onTab(e)) ||
+      this.props.handleKeyCommand('tab', this.props.editorState, e);
   },
 
   onUpArrow(e) {
-    return (this.props.onUpArrow && this.props.onUpArrow(e)) || this.props.handleKeyCommand('up-arrow', e);
+    return (this.props.onUpArrow && this.props.onUpArrow(e)) ||
+      this.props.handleKeyCommand('up-arrow', this.props.editorState, e);
   },
 
   onDownArrow(e) {
-    return (this.props.onDownArrow && this.props.onDownArrow(e)) || this.props.handleKeyCommand('down-arrow', e);
+    return (this.props.onDownArrow && this.props.onDownArrow(e)) ||
+      this.props.handleKeyCommand('down-arrow', this.props.editorState, e);
   },
 
   focus() {

--- a/src/components/KeyCommandController.js
+++ b/src/components/KeyCommandController.js
@@ -81,7 +81,7 @@ const KeyCommandController = (Component) => createReactClass({
     this.keyCommandListeners = this.keyCommandListeners.filterNot((l) => l === listener);
   },
 
-  handleKeyCommand(command, keyboardEvent = null) {
+  handleKeyCommand(command, __editorState, keyboardEvent = null) {
     const {editorState, onChange, handleKeyCommand} = this.props;
 
     if (handleKeyCommand) {


### PR DESCRIPTION
In https://github.com/facebook/draft-js/pull/1112 `editorState` is now passed as a parameter to `handleKeyCommand` - this `EditorState` ended up being unexpectedly passed by `KeyCommandController` to listeners in the parameter spot that a keyboard event would have been (though none are generated by `handleKeyCommand`-sourced commands, they are by `return`, `escape`, `tab`, and arrow keys).