### PR TITLE
fix handleReturn parameters

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -107,8 +107,8 @@ const EditorWrapper = createReactClass({
     return getDefaultKeyBinding(e);
   },
 
-  handleReturn(e) {
-    return (this.props.handleReturn && this.props.handleReturn(e)) || this.props.handleKeyCommand('return', e);
+  handleReturn(e, editorState) {
+    return (this.props.handleReturn && this.props.handleReturn(e, editorState)) || this.props.handleKeyCommand('return', e);
   },
 
   onEscape(e) {


### PR DESCRIPTION
As of [draft-js#1113](https://github.com/facebook/draft-js/pull/1113/files), `editorState` is now passed to `handleReturn` as a second argument.