### PR TITLE
Expose a ref on the `Editor` via context

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -44,7 +44,8 @@ const EditorWrapper = createReactClass({
     setReadOnly: PropTypes.func,
     onChange: PropTypes.func,
     focus: PropTypes.func,
-    blur: PropTypes.func
+    blur: PropTypes.func,
+    editorRef: PropTypes.node
   },
 
   getDefaultProps() {
@@ -83,7 +84,8 @@ const EditorWrapper = createReactClass({
       setReadOnly: this.setReadOnly,
       onChange: this.props.onChange,
       focus: this.focus,
-      blur: this.blur
+      blur: this.blur,
+      editorRef: this.refs.editor
     };
   },
 


### PR DESCRIPTION
Useful when plugins want access to the `Editor` instance for reasons other than calling `focus` or `blur` (e.g. measuring its DOM node).