### PR TITLE
Fix mistyped `editorRef`

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -45,7 +45,7 @@ const EditorWrapper = createReactClass({
     onChange: PropTypes.func,
     focus: PropTypes.func,
     blur: PropTypes.func,
-    editorRef: PropTypes.node
+    editorRef: PropTypes.object
   },
 
   getDefaultProps() {


### PR DESCRIPTION
I accidentally introduced a propType error in https://github.com/HubSpot/draft-extend/pull/40. This fixes that.