### PR TITLE
Upgrade to React 17 Context API 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 2.0.0
+
+- Upgrade to utilize React Context API
+- Exposes the `DraftEditorContext` React context

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   "license": "Apache License 2.0",
   "peerDependencies": {
     "draft-js": ">=0.7.0",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
@@ -48,8 +48,8 @@
     "draft-convert": "^2.1.4",
     "draft-js": "^0.10.5",
     "es6-shim": "^0.35.0",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "rollup": "^1.26.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   "license": "Apache License 2.0",
   "peerDependencies": {
     "draft-js": ">=0.7.0",
-    "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
@@ -48,8 +48,8 @@
     "draft-convert": "^2.1.4",
     "draft-js": "^0.10.5",
     "es6-shim": "^0.35.0",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0",
     "rollup": "^1.26.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-extend",
-  "version": "2.0.0",
+  "version": "1.7.0-beta.1",
   "description": "Build extensible Draft.js editors with configurable plugins and integrated serialization.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   "license": "Apache License 2.0",
   "peerDependencies": {
     "draft-js": ">=0.7.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
@@ -48,8 +48,8 @@
     "draft-convert": "^2.1.4",
     "draft-js": "^0.10.5",
     "es6-shim": "^0.35.0",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0",
     "rollup": "^1.26.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-extend",
-  "version": "1.7.0-beta.1",
+  "version": "2.0.0",
   "description": "Build extensible Draft.js editors with configurable plugins and integrated serialization.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -34,6 +34,17 @@ const propTypes = {
   renderTray: PropTypes.func,
 };
 
+const defaultContextFn = () => console.error('DraftEditorContext is not provided in this scope.  Please check your setup.')
+export const DraftEditorContext = React.createContext({
+  getEditorState: defaultContextFn,
+  getReadOnly:defaultContextFn,
+  setReadOnly: defaultContextFn,
+  onChange: defaultContextFn,
+  focus: defaultContextFn,
+  blur: defaultContextFn,
+  editorRef: defaultContextFn,
+});
+
 class EditorWrapper extends React.Component {
   constructor(props) {
     super(props);
@@ -58,10 +69,8 @@ class EditorWrapper extends React.Component {
     this.getReadOnly = this.getReadOnly.bind(this);
     this.setReadOnly = this.setReadOnly.bind(this);
     this.getDecoratedState = this.getDecoratedState.bind(this);
-  }
 
-  getChildContext() {
-    return {
+    this.contextValue = {
       getEditorState: this.getDecoratedState,
       getReadOnly: this.getReadOnly,
       setReadOnly: this.setReadOnly,
@@ -261,33 +270,35 @@ class EditorWrapper extends React.Component {
     const readOnly = this.getReadOnly();
 
     return (
-      <div className={className}>
-        <div className="draft-extend-editor">
-          <Editor
-            {...otherProps}
-            ref="editor"
-            editorState={decoratedState}
-            readOnly={readOnly}
-            onChange={onChange}
-            blockStyleFn={blockStyleFn}
-            blockRendererFn={blockRendererFn}
-            customStyleMap={styleMap}
-            customStyleFn={styleFn}
-            handleKeyCommand={handleKeyCommand}
-            keyBindingFn={this.keyBindingFn}
-            handleReturn={this.handleReturn}
-            onEscape={this.onEscape}
-            onTab={this.onTab}
-            onUpArrow={this.onUpArrow}
-            onDownArrow={this.onDownArrow}
-          />
-          <div className="draft-extend-tray">{this.renderTray()}</div>
-          <div className="draft-extend-controls">
-            {this.renderPluginButtons()}
+      <DraftEditorContext.Provider value={this.contextValue}>
+        <div className={className}>
+          <div className="draft-extend-editor">
+            <Editor
+              {...otherProps}
+              ref="editor"
+              editorState={decoratedState}
+              readOnly={readOnly}
+              onChange={onChange}
+              blockStyleFn={blockStyleFn}
+              blockRendererFn={blockRendererFn}
+              customStyleMap={styleMap}
+              customStyleFn={styleFn}
+              handleKeyCommand={handleKeyCommand}
+              keyBindingFn={this.keyBindingFn}
+              handleReturn={this.handleReturn}
+              onEscape={this.onEscape}
+              onTab={this.onTab}
+              onUpArrow={this.onUpArrow}
+              onDownArrow={this.onDownArrow}
+            />
+            <div className="draft-extend-tray">{this.renderTray()}</div>
+            <div className="draft-extend-controls">
+              {this.renderPluginButtons()}
+            </div>
+            <div className="draft-extend-overlays">{this.renderOverlays()}</div>
           </div>
-          <div className="draft-extend-overlays">{this.renderOverlays()}</div>
         </div>
-      </div>
+      </DraftEditorContext.Provider>
     );
   }
 }
@@ -309,16 +320,6 @@ EditorWrapper.defaultProps = {
   keyBindingFn: () => {},
   readOnly: false,
   showButtons: true,
-};
-
-EditorWrapper.childContextTypes = {
-  getEditorState: PropTypes.func,
-  getReadOnly: PropTypes.func,
-  setReadOnly: PropTypes.func,
-  onChange: PropTypes.func,
-  focus: PropTypes.func,
-  blur: PropTypes.func,
-  editorRef: PropTypes.object,
 };
 
 export default KeyCommandController(EditorWrapper);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import Editor from './components/Editor';
+import Editor, { DraftEditorContext } from './components/Editor';
 import Toolbar from './components/Toolbar';
 import KeyCommandController from './components/KeyCommandController';
 import createPlugin from './plugins/createPlugin';
@@ -14,4 +14,5 @@ export {
   accumulatePluginOptions,
   pluginUtils,
   compose,
+  DraftEditorContext
 };


### PR DESCRIPTION
HubSpot is moving to utilize the updated React context guidelines to allow for React 17 usage. 

This requires us to remove usage of the Legacy context API in favor of the new setup.  A major version bump is included in this, as it will break dependents of the legacy API.

React Context docs here: https://issues.hubspotcentral.com/browse/HMI-10341

